### PR TITLE
Fix failure during install for cmake multi-config generators

### DIFF
--- a/cmake_modules/install_package.cmake
+++ b/cmake_modules/install_package.cmake
@@ -141,7 +141,7 @@ function(install_package)
 
         # install library itself
         if( PACKAGE_LIB_NAME )
-            install( FILES ${_target_library} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib )
+            install( TARGETS ${PACKAGE_LIB_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib )
             set( PACKAGE_LIB_LINK "-l${PACKAGE_LIB_NAME}" )
         endif()
     


### PR DESCRIPTION
Current cmake build fails during install when using a multi-config generator. The `_target_library` string ends up containing a `$(Configuration)` variable that does not get evaluated. In a multi-config environment the build configuration is not known until build time. Switching to `TARGETS` handles this regardless of the generator.
