### PR TITLE
Adjust CVars -> cvars to eliminate case sensitivity

### DIFF
--- a/examples/GlutConsole/GlutConsoleDemo.cpp
+++ b/examples/GlutConsole/GlutConsoleDemo.cpp
@@ -14,16 +14,16 @@
 #include <iostream>
 #include <vector>
 #include <map>
-#include <CVars/glplatform.h>
+#include <cvars/glplatform.h>
 
 //include this header for CVars and GLConsole
 #include <GLConsole/GLConsole.h>
 
 //A CVar version of std::vector
-#include <CVars/CVarVectorIO.h>
+#include <cvars/CVarVectorIO.h>
 
 //A CVar version of std::map
-#include <CVars/CVarMapIO.h>
+#include <cvars/CVarMapIO.h>
 
 
 // Single global instance so glut can get access

--- a/include/GLConsole/GLConsole.h
+++ b/include/GLConsole/GLConsole.h
@@ -10,9 +10,9 @@
 #define __GLCONSOLE_H__
 
 
-#include <CVars/CVar.h>
-#include <CVars/Timestamp.h>
-#include <CVars/glplatform.h>
+#include <cvars/CVar.h>
+#include <cvars/Timestamp.h>
+#include <cvars/glplatform.h>
 
 #include <GLConsole/GLFont.h>
 //#include <GLConsole/GLColor.h>
@@ -338,8 +338,8 @@ class GLConsole
 #include <algorithm>
 #include <cstring>
 
-#include <CVars/CVar.h>
-#include <CVars/TrieNode.h>
+#include <cvars/CVar.h>
+#include <cvars/TrieNode.h>
 
 
 /// Include a collection of useful "ConsoleFunc" functiions:

--- a/include/GLConsole/GLFont.h
+++ b/include/GLConsole/GLFont.h
@@ -8,7 +8,7 @@
 #ifndef __GL_FONT_H__
 #define __GL_FONT_H__
 
-#include <CVars/glplatform.h>
+#include <cvars/glplatform.h>
 
 #include <assert.h>
 #include <stdio.h>

--- a/include/cvars/glplatform.h
+++ b/include/cvars/glplatform.h
@@ -71,4 +71,10 @@
     #endif
 #endif // HAVE_GLES
 
+#ifdef HAVE_FREEGLUT
+ #include <GL/gl.h>
+ #include <GL/glu.h>
+ #include <GL/glut.h>
+#endif
+
 #endif // CVARS_GLPLATFORM_H


### PR DESCRIPTION
Chris, in response to PR #15, I've been holding onto similar changes for awhile to get ARPG tools to build on Linux. I've addressed the case sensitivity issue with a light hand, so that only the directory name changed, not the header file names. Also, I've added a freeglut check using a #define from the CMake config.h to detect if FreeGlut is installed on Linux. This builds on Arch with freeglut 3. 