### PR TITLE
Fixed include directives in exampels. Addes missing unistd.h

### DIFF
--- a/examples/Demo2/Pyramid.cc
+++ b/examples/Demo2/Pyramid.cc
@@ -1,6 +1,6 @@
 
-#include <CVars/CVar.h>
-#include <CVars/glplatform.h>
+#include <cvars/CVar.h>
+#include <cvars/glplatform.h>
 #include "Pyramid.h"
 
 /**

--- a/examples/Demo2/demo2.cc
+++ b/examples/Demo2/demo2.cc
@@ -2,7 +2,6 @@
 #include <stdio.h>
 #include <math.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <cvars/glplatform.h>
 #include <GLConsole/GLConsole.h>
 
@@ -11,6 +10,10 @@
 
 #include <vector>
 #include <map>
+
+#ifdef __unix__
+#include <unistd.h> /* needed for usleep */
+#endif
 
 #include "Pyramid.h"
 

--- a/examples/Demo2/demo2.cc
+++ b/examples/Demo2/demo2.cc
@@ -2,12 +2,12 @@
 #include <stdio.h>
 #include <math.h>
 #include <stdlib.h>
-
-#include <CVars/glplatform.h>
+#include <unistd.h>
+#include <cvars/glplatform.h>
 #include <GLConsole/GLConsole.h>
 
-#include <CVars/CVarVectorIO.h>
-#include <CVars/CVarMapIO.h>
+#include <cvars/CVarVectorIO.h>
+#include <cvars/CVarMapIO.h>
 
 #include <vector>
 #include <map>

--- a/include/FLConsole/FLConsole.h
+++ b/include/FLConsole/FLConsole.h
@@ -9,8 +9,8 @@
 #ifndef __FLCONSOLE_H__
 #define __FLCONSOLE_H__
 
-#include <CVars/CVar.h> 
-#include <CVars/Timestamp.h>
+#include <cvars/CVar.h> 
+#include <cvars/Timestamp.h>
 
 //#include <GLConsole/CVarUtils::Color.h>
 

--- a/include/TextConsole/TextConsole.h
+++ b/include/TextConsole/TextConsole.h
@@ -9,8 +9,8 @@
 #ifndef __TEXT_CONSOLE_H__
 #define __TEXT_CONSOLE_H__
 
-#include <CVars/CVar.h> 
-#include <CVars/Timestamp.h>
+#include <cvars/CVar.h> 
+#include <cvars/Timestamp.h>
 
 #include <limits.h>
 #include <stdio.h>


### PR DESCRIPTION
Examples after the previous renames still starting with uppercase letters when reffering to cvars. Demo2 was missing include directive for unistd.h (needed for usleep()).